### PR TITLE
Add "enabled" to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ And then execute:
 
 ```ruby
 SidekiqEcsScaler.configure do |config|
+  # enable / disable of scaler, default is true
+  config.enabled = true
+
   # queue to monitor latency, default is "default"
   config.queue_name = "default"
 

--- a/lib/sidekiq-ecs-scaler/client.rb
+++ b/lib/sidekiq-ecs-scaler/client.rb
@@ -11,7 +11,7 @@ module SidekiqEcsScaler
 
     # @return [Integer, nil]
     def update_desired_count
-      return unless config.task_meta
+      return if !config.enabled || config.task_meta.nil?
 
       desired_count_by_latency.then do |desired_count|
         describe_service.then do |service|

--- a/lib/sidekiq-ecs-scaler/configuration.rb
+++ b/lib/sidekiq-ecs-scaler/configuration.rb
@@ -3,6 +3,9 @@
 module SidekiqEcsScaler
   # SidekiqEcsScaler::Configuration
   class Configuration
+    # @!attribute [r] enabled
+    # @return [Boolean]
+    attr_reader :enabled
     # @!attribute [r] queue_name
     # @return [String]
     attr_reader :queue_name
@@ -18,9 +21,6 @@ module SidekiqEcsScaler
     # @!attribute [r] task_meta
     # @return [SidekiqEcsScaler::TaskMetaV4, nil]
     attr_reader :task_meta
-    # @!attribute [r] ecs_client
-    # @return [Aws::ECS::Client]
-    attr_reader :ecs_client
 
     # @return [void]
     def initialize
@@ -28,8 +28,17 @@ module SidekiqEcsScaler
       @min_count = 1
       @max_count = 1
       @max_latency = 3600
-      @ecs_client = Aws::ECS::Client.new
       @task_meta = TaskMetaV4.build_or_null
+      @enabled = true
+    end
+
+    # @param enabled [Boolean]
+    # @return [void]
+    # @raise [ArgumentError]
+    def enabled=(enabled)
+      raise ArgumentError if !enabled.is_a?(TrueClass) && !enabled.is_a?(FalseClass)
+
+      @enabled = enabled
     end
 
     # @param queue_name [String]
@@ -67,6 +76,11 @@ module SidekiqEcsScaler
       raise ArgumentError if max_count > max_latency
 
       @max_latency = max_latency
+    end
+
+    # @return [Aws::ECS::Client]
+    def ecs_client
+      @ecs_client ||= Aws::ECS::Client.new
     end
 
     # @param ecs_client [Aws::ECS::Client]

--- a/sig/sidekiq-ecs-scaler.rbs
+++ b/sig/sidekiq-ecs-scaler.rbs
@@ -31,6 +31,8 @@ module SidekiqEcsScaler
   end
 
   class Configuration
+    attr_reader enabled: bool
+
     attr_accessor queue_name: ::String
 
     attr_reader min_count: ::Integer
@@ -41,15 +43,17 @@ module SidekiqEcsScaler
 
     attr_reader task_meta: ::SidekiqEcsScaler::TaskMetaV4?
 
-    attr_reader ecs_client: ::Aws::ECS::Client
-
     def initialize: () -> void
+
+    def enabled=: (bool) -> void
 
     def min_count=: (::Integer) -> void
 
     def max_count=: (::Integer) -> void
 
     def max_latency=: (::Integer) -> void
+
+    def ecs_client: () -> ::Aws::ECS::Client
 
     def ecs_client=: (::Aws::ECS::Client) -> void
 

--- a/spec/sidekiq-ecs-scaler/client_spec.rb
+++ b/spec/sidekiq-ecs-scaler/client_spec.rb
@@ -10,59 +10,57 @@ RSpec.describe SidekiqEcsScaler::Client do
       c.max_count = 10
       c.max_latency = 3600
       c.ecs_client = ecs_client
+      c.enabled = enabled
     end
   end
 
+  let(:enabled) { true }
+
   let(:ecs_client) { Aws::ECS::Client.new(stub_responses: true) }
+
+  let(:stub_task_meta) do
+    SidekiqEcsScaler::TaskMetaV4.new({ "Cluster" => "local", "TaskARN" => "ARN" })
+  end
+
+  let(:queue) do
+    Class.new do
+      def latency
+        1800
+      end
+    end.new
+  end
+
+  let(:stub_tasks) { [{ group: "service:local" }] }
+
+  let(:stub_services) { [{ cluster_arn: "cluster", service_name: "service", desired_count: 1 }] }
+
+  before do
+    allow(config).to receive(:task_meta).and_return(stub_task_meta)
+    allow(Sidekiq::Queue).to receive(:new).with("highest").and_return(queue)
+    ecs_client.stub_responses(:describe_tasks, tasks: stub_tasks)
+    ecs_client.stub_responses(:describe_services, services: stub_services)
+  end
 
   describe "#update_desired_count" do
     subject(:update) { client.update_desired_count }
 
+    context "when config enabled is false" do
+      let(:enabled) { false }
+
+      it { is_expected.to be_nil }
+    end
+
     context "when task meta is null" do
-      before do
-        allow(config).to receive(:task_meta).and_return(nil)
-      end
+      let(:stub_task_meta) { nil }
 
       it { is_expected.to be_nil }
     end
 
     context "when queue latency is less than max latency" do
-      before do
-        allow(config).to receive(:task_meta).and_return(
-          SidekiqEcsScaler::TaskMetaV4.new({ "Cluster" => "local", "TaskARN" => "ARN" })
-        )
-        allow(Sidekiq::Queue).to receive(:new).with("highest").and_return(queue)
-        ecs_client.stub_responses(:describe_tasks, tasks: [{ group: "service:local" }])
-        ecs_client.stub_responses(
-          :describe_services,
-          services: [{ cluster_arn: "cluster", service_name: "service", desired_count: 1 }]
-        )
-      end
-
-      let(:queue) do
-        Class.new do
-          def latency
-            1800
-          end
-        end.new
-      end
-
       it { is_expected.to eq 6 }
     end
 
     context "when queue latency is grater than max_latency" do
-      before do
-        allow(config).to receive(:task_meta).and_return(
-          SidekiqEcsScaler::TaskMetaV4.new({ "Cluster" => "local", "TaskARN" => "ARN" })
-        )
-        allow(Sidekiq::Queue).to receive(:new).with("highest").and_return(queue)
-        ecs_client.stub_responses(:describe_tasks, tasks: [{ group: "service:local" }])
-        ecs_client.stub_responses(
-          :describe_services,
-          services: [{ cluster_arn: "cluster", service_name: "service", desired_count: 1 }]
-        )
-      end
-
       let(:queue) do
         Class.new do
           def latency
@@ -75,49 +73,15 @@ RSpec.describe SidekiqEcsScaler::Client do
     end
 
     context "when desired_count is not changed" do
-      before do
-        allow(config).to receive(:task_meta).and_return(
-          SidekiqEcsScaler::TaskMetaV4.new({ "Cluster" => "local", "TaskARN" => "ARN" })
-        )
-        allow(Sidekiq::Queue).to receive(:new).with("highest").and_return(queue)
-        ecs_client.stub_responses(:describe_tasks, tasks: [{ group: "service:local" }])
-        ecs_client.stub_responses(
-          :describe_services,
-          services: [{ cluster_arn: "cluster", service_name: "service", desired_count: 6 }]
-        )
-      end
-
-      let(:queue) do
-        Class.new do
-          def latency
-            1800
-          end
-        end.new
-      end
+      let(:stub_services) { [{ cluster_arn: "cluster", service_name: "service", desired_count: 6 }] }
 
       it { is_expected.to eq 6 }
     end
 
     context "when task is not found" do
-      before do
-        allow(config).to receive(:task_meta).and_return(
-          SidekiqEcsScaler::TaskMetaV4.new({ "Cluster" => "local", "TaskARN" => "ARN" })
-        )
-        allow(Sidekiq::Queue).to receive(:new).with("highest").and_return(queue)
-        ecs_client.stub_responses(:describe_tasks, tasks: [])
-      end
+      let(:stub_tasks) { [] }
 
-      let(:queue) do
-        Class.new do
-          def latency
-            1800
-          end
-        end.new
-      end
-
-      it do
-        expect { update }.to raise_error(SidekiqEcsScaler::Error)
-      end
+      it { expect { update }.to raise_error(SidekiqEcsScaler::Error) }
     end
   end
 end

--- a/spec/sidekiq-ecs-scaler/configuration_spec.rb
+++ b/spec/sidekiq-ecs-scaler/configuration_spec.rb
@@ -3,6 +3,42 @@
 RSpec.describe SidekiqEcsScaler::Configuration do
   let(:configuration) { described_class.new }
 
+  describe "#enabled" do
+    subject { configuration.enabled }
+
+    context "when default" do
+      it { is_expected.to eq true }
+    end
+  end
+
+  describe "#enabled=" do
+    subject(:write) { configuration.enabled = enabled }
+
+    context "when enabled is true" do
+      let(:enabled) { true }
+
+      it do
+        expect { write }.not_to change(configuration, :enabled).from(true)
+      end
+    end
+
+    context "when enabled is false" do
+      let(:enabled) { false }
+
+      it do
+        expect { write }.to change(configuration, :enabled).to(false)
+      end
+    end
+
+    context "when enabled is invalid" do
+      let(:enabled) { "true" }
+
+      it do
+        expect { write }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
   describe "#queue_name" do
     subject { configuration.queue_name }
 
@@ -12,7 +48,7 @@ RSpec.describe SidekiqEcsScaler::Configuration do
   end
 
   describe "#queue_name=" do
-    subject(:write) { configuration.queue_name = (queue_name) }
+    subject(:write) { configuration.queue_name = queue_name }
 
     context "when argument is valid" do
       let(:queue_name) { "highest" }


### PR DESCRIPTION
Added a setting that can optionally disable the scaler.

And

changed AWS::ECS::Client to lazy evaluation.

In a development environment that does not need to be operated,
there may be an error due to lack of environment variables.